### PR TITLE
Connection pool

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,7 +171,7 @@ func (client *Client) getCertificate() error {
 	return err
 }
 
-// Returns a connection pool used to send message payloads.
+// getConnectionPool returns a connection pool used to send message payloads.
 func (client *Client) getConnectionPool() (*ConnectionPool, error) {
 	if client.pool != nil {
 		return client.pool, nil

--- a/client.go
+++ b/client.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+var _ APNSClient = &Client{}
+
+// APNSClient is an APNS client.
+type APNSClient interface {
+	ConnectAndWrite(resp *PushNotificationResponse, payload []byte) (err error)
+	Send(pn *PushNotification) (resp *PushNotificationResponse)
+}
+
 // Client contains the fields necessary to communicate
 // with Apple, such as the gateway to use and your
 // certificate contents.
@@ -100,7 +108,7 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ServerName: gatewayParts[0],
+		ServerName:   gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -96,8 +97,10 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 		return err
 	}
 
+	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		ServerName: gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/client.go
+++ b/client.go
@@ -3,10 +3,11 @@ package apns
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
-	"net"
-	"strings"
 	"time"
+)
+
+const (
+	numConnections = 5 // number of connections in the collection pool
 )
 
 var _ APNSClient = &Client{}
@@ -35,6 +36,7 @@ type Client struct {
 	KeyBase64         string
 	certificate       tls.Certificate
 	apnsConnection    *tls.Conn
+	pool              *ConnectionPool
 }
 
 // BareClient can be used to set the contents of your
@@ -94,48 +96,16 @@ func (client *Client) Send(pn *PushNotification) (resp *PushNotificationResponse
 // possible to get a false positive if Apple takes a long time to respond.
 // It's probably not a deal-breaker, but something to be aware of.
 func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []byte) error {
-	var bytesWritten int
-	var err error
-
-	if client.apnsConnection == nil {
-		// We want to re-establish the connection to APNS after a number of messages sent
-		err = client.openConnection()
-		if err != nil {
-			return err
-		}
-	}
-
-	bytesWritten, err = client.apnsConnection.Write(payload)
+	// Get the connection pool
+	p, err := client.getConnectionPool()
 	if err != nil {
-		if err.Error() != "use of closed network connection" && err.Error() != "EOF" && !strings.Contains(err.Error(), "broken pipe") && err.Error() != "connection reset by peer" {
-			if client.apnsConnection != nil {
-				client.apnsConnection.Close()
-			}
-			client.apnsConnection = nil
-			return err
-		}
-
-		// If the connection is closed, reconnect
-		err = client.openConnection()
-		if err != nil {
-			return err
-		}
-
-		bytesWritten, err = client.apnsConnection.Write(payload)
-		if err != nil {
-			if client.apnsConnection != nil {
-				client.apnsConnection.Close()
-			}
-			client.apnsConnection = nil
-			return err
-		}
+		return err
 	}
 
-	// re-connect if no bytes were written
-	if bytesWritten == 0 {
-		client.apnsConnection.Close()
-		client.apnsConnection = nil
-		return fmt.Errorf("Could not open connection to %s.  Please try again.", client.Gateway)
+	// Attempt to write to the pool
+	c, _, err := p.Write(payload)
+	if err != nil {
+		return err
 	}
 
 	// Create one channel that will serve to handle
@@ -151,7 +121,13 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 	responseChannel := make(chan []byte, 1)
 	go func() {
 		buffer := make([]byte, 6, 6)
-		client.apnsConnection.Read(buffer)
+		_, err := c.Read(buffer)
+
+		// on read error, close the connection
+		if err != nil {
+			c.Close()
+		}
+
 		responseChannel <- buffer
 	}()
 
@@ -170,43 +146,10 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 		err = errors.New(resp.AppleResponse)
 	case <-timeoutChannel:
 		resp.Success = true
+		err = nil
 	}
 
 	return err
-}
-
-// Opens a connection to the Apple APNS server
-// The connection is created and persisted to the client's apnsConnection property
-//	to save on the overhead of the crypto libraries.
-func (client *Client) openConnection() error {
-	if client.apnsConnection != nil {
-		client.apnsConnection.Close()
-	}
-
-	err := client.getCertificate()
-	if err != nil {
-		return err
-	}
-
-	gatewayParts := strings.Split(client.Gateway, ":")
-	conf := &tls.Config{
-		Certificates: []tls.Certificate{client.certificate},
-		ServerName:   gatewayParts[0],
-	}
-
-	conn, err := net.Dial("tcp", client.Gateway)
-	if err != nil {
-		return err
-	}
-
-	tlsConn := tls.Client(conn, conf)
-	err = tlsConn.Handshake()
-	if err != nil {
-		return err
-	}
-
-	client.apnsConnection = tlsConn
-	return nil
 }
 
 // Returns a certificate to use to send the notification.
@@ -226,4 +169,20 @@ func (client *Client) getCertificate() error {
 	}
 
 	return err
+}
+
+// Returns a connection pool used to send message payloads.
+func (client *Client) getConnectionPool() (*ConnectionPool, error) {
+	if client.pool != nil {
+		return client.pool, nil
+	}
+
+	err := client.getCertificate()
+	if err != nil {
+		return nil, err
+	} else {
+		client.pool = NewConnectionPool(numConnections, client.Gateway, client.certificate)
+	}
+
+	return client.pool, err
 }

--- a/client_mock.go
+++ b/client_mock.go
@@ -1,0 +1,21 @@
+package apns
+
+import "github.com/stretchr/testify/mock"
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) ConnectAndWrite(resp *PushNotificationResponse, payload []byte) (err error) {
+	return m.Called(resp, payload).Error(0)
+}
+
+func (m *MockClient) Send(pn *PushNotification) (resp *PushNotificationResponse) {
+	r := m.Called(pn).Get(0)
+	if r != nil {
+		if r, ok := r.(*PushNotificationResponse); ok {
+			return r
+		}
+	}
+	return nil
+}

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -1,0 +1,24 @@
+package apns
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockClientConnectAndWrite(t *testing.T) {
+	m := &MockClient{}
+	m.On("ConnectAndWrite", (*PushNotificationResponse)(nil), []byte(nil)).Return(nil)
+	assert.Nil(t, m.ConnectAndWrite(nil, nil))
+	m.On("ConnectAndWrite", &PushNotificationResponse{}, []byte{}).Return(errors.New("test"))
+	assert.Equal(t, errors.New("test"), m.ConnectAndWrite(&PushNotificationResponse{}, []byte{}))
+}
+
+func TestMockClientSend(t *testing.T) {
+	m := &MockClient{}
+	m.On("Send", (*PushNotification)(nil)).Return(nil)
+	assert.Nil(t, m.Send(nil))
+	m.On("Send", &PushNotification{}).Return(&PushNotificationResponse{})
+	assert.Equal(t, &PushNotificationResponse{}, m.Send(&PushNotification{}))
+}

--- a/connection.go
+++ b/connection.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	handShakeTimeout = 5   // seconds
-	peekTimeout      = 250 // miliseconds
-	peekFrequency    = 25  // every N writes
-	keepAlive        = 10  // minutes
+	handShakeTimeout  = 5   // seconds
+	peekTimeout       = 250 // miliseconds
+	peekFrequency     = 25  // every N writes
+	keepAlive         = 10  // minutes
+	ErrorNoConnection = "no connection"
 )
 
 type Connection struct {
@@ -71,7 +72,7 @@ func (c *Connection) IsOpen() bool {
 
 func (c *Connection) Peek() error {
 	if c.connection == nil {
-		return errors.New("no connection")
+		return errors.New(ErrorNoConnection)
 	}
 
 	// attempt to peek at one byte
@@ -105,14 +106,14 @@ func (c *Connection) Close() error {
 
 func (c *Connection) Read(b []byte) (n int, err error) {
 	if !c.IsOpen() {
-		return 0, errors.New("no connection")
+		return 0, errors.New(ErrorNoConnection)
 	}
 	return c.connection.Read(b)
 }
 
 func (c *Connection) Write(b []byte) (n int, err error) {
 	if !c.IsOpen() {
-		return 0, errors.New("no connection")
+		return 0, errors.New(ErrorNoConnection)
 	}
 
 	c.writeCount++
@@ -135,21 +136,21 @@ func (c *Connection) RemoteAddr() net.Addr {
 
 func (c *Connection) SetDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New("no connection")
+		return errors.New(ErrorNoConnection)
 	}
 	return c.connection.SetDeadline(t)
 }
 
 func (c *Connection) SetReadDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New("no connection")
+		return errors.New(ErrorNoConnection)
 	}
 	return c.connection.SetReadDeadline(t)
 }
 
 func (c *Connection) SetWriteDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New("no connection")
+		return errors.New(ErrorNoConnection)
 	}
 	return c.connection.SetWriteDeadline(t)
 }

--- a/connection.go
+++ b/connection.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	handShakeTimeout  = 5   // seconds
-	peekTimeout       = 250 // miliseconds
-	peekFrequency     = 25  // every N writes
-	keepAlive         = 10  // minutes
-	ErrorNoConnection = "no connection"
+	handShakeTimeout = 5   // seconds
+	peekTimeout      = 250 // miliseconds
+	peekFrequency    = 25  // every N writes
+	keepAlive        = 10  // minutes
 )
+
+var ErrNoConnection = errors.New("no connection")
 
 type Connection struct {
 	connection  *tls.Conn
@@ -72,7 +73,7 @@ func (c *Connection) IsOpen() bool {
 
 func (c *Connection) Peek() error {
 	if c.connection == nil {
-		return errors.New(ErrorNoConnection)
+		return ErrNoConnection
 	}
 
 	// attempt to peek at one byte
@@ -106,14 +107,14 @@ func (c *Connection) Close() error {
 
 func (c *Connection) Read(b []byte) (n int, err error) {
 	if !c.IsOpen() {
-		return 0, errors.New(ErrorNoConnection)
+		return 0, ErrNoConnection
 	}
 	return c.connection.Read(b)
 }
 
 func (c *Connection) Write(b []byte) (n int, err error) {
 	if !c.IsOpen() {
-		return 0, errors.New(ErrorNoConnection)
+		return 0, ErrNoConnection
 	}
 
 	c.writeCount++
@@ -136,21 +137,21 @@ func (c *Connection) RemoteAddr() net.Addr {
 
 func (c *Connection) SetDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New(ErrorNoConnection)
+		return ErrNoConnection
 	}
 	return c.connection.SetDeadline(t)
 }
 
 func (c *Connection) SetReadDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New(ErrorNoConnection)
+		return ErrNoConnection
 	}
 	return c.connection.SetReadDeadline(t)
 }
 
 func (c *Connection) SetWriteDeadline(t time.Time) error {
 	if !c.IsOpen() {
-		return errors.New(ErrorNoConnection)
+		return ErrNoConnection
 	}
 	return c.connection.SetWriteDeadline(t)
 }

--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,162 @@
+package apns
+
+import (
+	"bufio"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	handShakeTimeout = 5   // seconds
+	peekTimeout      = 250 // miliseconds
+	peekFrequency    = 25  // every N writes
+	keepAlive        = 10  // minutes
+)
+
+type Connection struct {
+	connection  *tls.Conn
+	writeCount  int
+	connectTime time.Time
+}
+
+type Connectioner interface {
+	Write(b []byte) (n int, err error)
+}
+
+func (c *Connection) Open(gateway string, config *tls.Config) error {
+	// connect to the gateway
+	nc, err := net.Dial("tcp", gateway)
+	if err != nil {
+		return err
+	}
+
+	// attempt a handshake
+	tc := tls.Client(nc, config)
+	tc.SetDeadline(time.Now().Add(time.Duration(handShakeTimeout) * time.Second))
+	if err = tc.Handshake(); err != nil {
+		return err
+	}
+	tc.SetDeadline(time.Time{})
+
+	// keep the connection
+	c.connection = tc
+	c.connectTime = time.Now()
+	c.writeCount = 0
+
+	return nil
+}
+
+func (c *Connection) IsOpen() bool {
+	if c.connection == nil {
+		return false
+	}
+
+	// has the connection expired?
+	if time.Now().After(c.connectTime.Add(time.Duration(keepAlive) * time.Minute)) {
+		return false
+	}
+
+	// should we check if the connection is still alive?
+	if c.writeCount > 0 && c.writeCount%peekFrequency == 0 {
+		if err := c.Peek(); err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *Connection) Peek() error {
+	if c.connection == nil {
+		return errors.New("no connection")
+	}
+
+	// attempt to peek at one byte
+	// if we get an EOF, close the connection
+	reader := bufio.NewReader(c.connection)
+	c.connection.SetReadDeadline(time.Now().Add(time.Duration(peekTimeout) * time.Millisecond))
+	if _, err := reader.Peek(1); err == io.EOF {
+		c.Close()
+		return err
+	}
+
+	c.connection.SetReadDeadline(time.Time{})
+
+	return nil
+}
+
+func (c *Connection) Close() error {
+	if c.connection == nil {
+		return nil
+	}
+
+	err := c.connection.Close()
+	if err == nil {
+		c.connection = nil
+		c.writeCount = 0
+		c.connectTime = time.Time{}
+	}
+
+	return err
+}
+
+func (c *Connection) Read(b []byte) (n int, err error) {
+	if !c.IsOpen() {
+		return 0, errors.New("no connection")
+	}
+	return c.connection.Read(b)
+}
+
+func (c *Connection) Write(b []byte) (n int, err error) {
+	if !c.IsOpen() {
+		return 0, errors.New("no connection")
+	}
+
+	c.writeCount++
+	return c.connection.Write(b)
+}
+
+func (c *Connection) LocalAddr() net.Addr {
+	if !c.IsOpen() {
+		return nil
+	}
+	return c.connection.LocalAddr()
+}
+
+func (c *Connection) RemoteAddr() net.Addr {
+	if !c.IsOpen() {
+		return nil
+	}
+	return c.connection.RemoteAddr()
+}
+
+func (c *Connection) SetDeadline(t time.Time) error {
+	if !c.IsOpen() {
+		return errors.New("no connection")
+	}
+	return c.connection.SetDeadline(t)
+}
+
+func (c *Connection) SetReadDeadline(t time.Time) error {
+	if !c.IsOpen() {
+		return errors.New("no connection")
+	}
+	return c.connection.SetReadDeadline(t)
+}
+
+func (c *Connection) SetWriteDeadline(t time.Time) error {
+	if !c.IsOpen() {
+		return errors.New("no connection")
+	}
+	return c.connection.SetWriteDeadline(t)
+}
+
+func (c *Connection) ConnectionState() tls.ConnectionState {
+	if !c.IsOpen() {
+		return tls.ConnectionState{}
+	}
+	return c.connection.ConnectionState()
+}

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -1,0 +1,89 @@
+package apns
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+type ConnectionPool struct {
+	size        int
+	position    int
+	gateway     string
+	config      *tls.Config
+	connections []*Connection
+}
+
+func NewConnectionPool(numConnections int, gateway string, certificate tls.Certificate) *ConnectionPool {
+	gatewayParts := strings.Split(gateway, ":")
+	config := &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		ServerName:   gatewayParts[0],
+	}
+
+	c := ConnectionPool{
+		size:    numConnections,
+		gateway: gateway,
+		config:  config,
+	}
+
+	// init the connections
+	c.connections = make([]*Connection, c.size, c.size)
+	for i := 0; i < c.size; i++ {
+		c.connections[i] = &Connection{}
+	}
+
+	return &c
+}
+
+func (p *ConnectionPool) GetConnection() (*Connection, error) {
+	// our position is 1 to size
+	p.position++
+	if p.position > p.size {
+		p.position = 1
+	}
+
+	var err error
+	c := p.connections[p.position-1]
+	if !c.IsOpen() {
+		err = c.Open(p.gateway, p.config)
+	}
+
+	return c, err
+}
+
+func (p *ConnectionPool) Write(b []byte) (*Connection, int, error) {
+	var err error
+	var bytesWritten int
+	var c *Connection
+
+	for i := 0; i < p.size; i++ {
+		c, err = p.GetConnection()
+		if err != nil {
+			continue
+		}
+
+		bytesWritten, err = c.Write(b)
+		if err != nil || bytesWritten == 0 {
+			c.Close()
+			continue
+		}
+
+		break
+	}
+
+	if err == nil && bytesWritten == 0 && len(b) > 0 {
+		err = fmt.Errorf("no bytes written on connection - expected %d", len(b))
+	}
+
+	return c, bytesWritten, err
+}
+
+func (p *ConnectionPool) Close() error {
+	for i := 0; i < p.size; i++ {
+		if err := p.connections[i].Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/connection_pool_test.go
+++ b/connection_pool_test.go
@@ -1,0 +1,195 @@
+package apns
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestApnsNewConnectionPool(t *testing.T) {
+	Convey("NewConnectionPool()", t, func() {
+		credentials := [][]byte{[]byte("certificate")}
+		gateway := "mygateway"
+		certificate := tls.Certificate{Certificate: credentials}
+
+		Convey("Should store our gateway and certificate", func() {
+			p := NewConnectionPool(1, gateway, certificate)
+			So(p, ShouldNotBeNil)
+			So(p.size, ShouldEqual, 1)
+			So(p.gateway, ShouldEqual, gateway)
+			So(p.config.Certificates[0], ShouldResemble, certificate)
+			So(p.config.Certificates[0].Certificate, ShouldResemble, credentials)
+		})
+
+		Convey("Should support multiple connections", func() {
+			p := NewConnectionPool(5, gateway, certificate)
+			So(p, ShouldNotBeNil)
+			So(p.size, ShouldEqual, 5)
+			So(len(p.connections), ShouldEqual, 5)
+		})
+	})
+}
+
+func TestApnsConnectionPoolGetConnection(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	certificate := tls.Certificate{}
+	Convey("GetConnection()", t, func() {
+		Convey("Fake server should return an error", func() {
+			p := NewConnectionPool(1, "fake", certificate)
+			c, err := p.GetConnection()
+			So(c, ShouldNotBeNil)
+			So(c.IsOpen(), ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+			So(p.position, ShouldEqual, 1)
+		})
+
+		Convey("Pool of one, should return the same connection", func() {
+			p := NewConnectionPool(1, ts.URL[8:], ts.TLS.Certificates[0])
+			// need to skip verification for this to accept our cert
+			p.config.InsecureSkipVerify = true
+			c, err := p.GetConnection()
+			So(c, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(p.position, ShouldEqual, 1)
+
+			unique := c.ConnectionState().TLSUnique
+
+			Convey("Position should stay the same and connection should be re-used", func() {
+				c, err := p.GetConnection()
+				So(c, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(p.position, ShouldEqual, 1)
+				So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
+			})
+		})
+
+		Convey("Pool of two, should loop over connections", func() {
+			p := NewConnectionPool(2, ts.URL[8:], ts.TLS.Certificates[0])
+			So(p.position, ShouldEqual, 0)
+			// need to skip verification for this to accept our cert
+			p.config.InsecureSkipVerify = true
+			c, err := p.GetConnection()
+			So(c, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(p.position, ShouldEqual, 1)
+
+			unique := c.ConnectionState().TLSUnique
+
+			Convey("Position should increase and get a new connection", func() {
+				c, err := p.GetConnection()
+				So(c, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(p.position, ShouldEqual, 2)
+				So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+
+				unique2 := c.ConnectionState().TLSUnique
+
+				Convey("Position should go back to 1 and should re-use connection", func() {
+					c, err := p.GetConnection()
+					So(c, ShouldNotBeNil)
+					So(err, ShouldBeNil)
+					So(p.position, ShouldEqual, 1)
+					So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
+
+					Convey("Position should go back to 2 and should re-use connection", func() {
+						c, err := p.GetConnection()
+						So(c, ShouldNotBeNil)
+						So(err, ShouldBeNil)
+						So(p.position, ShouldEqual, 2)
+						So(c.ConnectionState().TLSUnique, ShouldResemble, unique2)
+					})
+				})
+
+			})
+
+		})
+	})
+}
+
+func TestApnsConnectionPoolWrite(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	poolSize := 10
+	Convey("Write()", t, func() {
+		p := NewConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
+		p.config.InsecureSkipVerify = true // need to skip verification for this to accept our cert
+
+		Convey("Bytes written should match", func() {
+			c, bytesWritten, err := p.Write([]byte("12345"))
+			So(err, ShouldBeNil)
+			So(bytesWritten, ShouldEqual, 5)
+			unique := c.ConnectionState().TLSUnique
+			Convey("Next write should be on different connection", func() {
+				c, bytesWritten, err := p.Write([]byte("test"))
+				So(err, ShouldBeNil)
+				So(bytesWritten, ShouldEqual, 4)
+				So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+			})
+
+			Convey("If we close all of the connections, should reconnect", func() {
+				p.Close()
+
+				_, bytesWritten, err := p.Write([]byte("6789"))
+				So(err, ShouldBeNil)
+				So(bytesWritten, ShouldEqual, 4)
+			})
+
+		})
+
+		/*
+			Convey("Should return an error if we write 0 bytes", func() {
+				//p.config.InsecureSkipVerify = false // set to false so the handshake fails
+				_, bytesWritten, err := p.Write([]byte("hello"))
+				So(bytesWritten, ShouldEqual, 0)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "foobar")
+			})
+		*/
+
+		Convey("Should give an error if the server is closed", func() {
+			ts.Close()
+
+			// force a peek
+			for i := 0; i < poolSize; i++ {
+				p.connections[i].writeCount = peekFrequency
+
+			}
+
+			_, _, err := p.Write([]byte("test"))
+			So(err, ShouldNotBeNil)
+
+		})
+	})
+}
+
+func TestApnsConnectionPoolClose(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	poolSize := 10
+	Convey("Close()", t, func() {
+		p := NewConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
+		p.config.InsecureSkipVerify = true // need to skip verification for this to accept our cert
+
+		Convey("Should not return an error if no open connections", func() {
+			err := p.Close()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Should not return an error if there are open connections", func() {
+			c, err := p.GetConnection()
+			So(err, ShouldBeNil)
+			So(c.IsOpen(), ShouldBeTrue)
+
+			err = p.Close()
+			So(err, ShouldBeNil)
+			So(c.IsOpen(), ShouldBeFalse)
+		})
+	})
+}

--- a/connection_pool_test.go
+++ b/connection_pool_test.go
@@ -9,6 +9,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func NewTestConnectionPool(numConnections int, gateway string, certificate tls.Certificate) *ConnectionPool {
+	p := NewConnectionPool(numConnections, gateway, certificate)
+	p.config.InsecureSkipVerify = true // we need to skip verification so our cert is accepted
+	return p
+}
+
 func TestApnsNewConnectionPool(t *testing.T) {
 	Convey("NewConnectionPool()", t, func() {
 		credentials := [][]byte{[]byte("certificate")}
@@ -16,7 +22,7 @@ func TestApnsNewConnectionPool(t *testing.T) {
 		certificate := tls.Certificate{Certificate: credentials}
 
 		Convey("Should store our gateway and certificate", func() {
-			p := NewConnectionPool(1, gateway, certificate)
+			p := NewTestConnectionPool(1, gateway, certificate)
 			So(p, ShouldNotBeNil)
 			So(p.size, ShouldEqual, 1)
 			So(p.gateway, ShouldEqual, gateway)
@@ -25,7 +31,7 @@ func TestApnsNewConnectionPool(t *testing.T) {
 		})
 
 		Convey("Should support multiple connections", func() {
-			p := NewConnectionPool(5, gateway, certificate)
+			p := NewTestConnectionPool(5, gateway, certificate)
 			So(p, ShouldNotBeNil)
 			So(p.size, ShouldEqual, 5)
 			So(len(p.connections), ShouldEqual, 5)
@@ -39,74 +45,81 @@ func TestApnsConnectionPoolGetConnection(t *testing.T) {
 
 	certificate := tls.Certificate{}
 	Convey("GetConnection()", t, func() {
-		Convey("Fake server should return an error", func() {
-			p := NewConnectionPool(1, "fake", certificate)
-			c, err := p.GetConnection()
-			So(c, ShouldNotBeNil)
-			So(c.IsOpen(), ShouldBeFalse)
-			So(err, ShouldNotBeNil)
-			So(p.position, ShouldEqual, 1)
+		Convey("When gateway is invalid", func() {
+			p := NewTestConnectionPool(1, "fake", certificate)
+			Convey("Should return an error", func() {
+				c, err := p.GetConnection()
+				So(c, ShouldNotBeNil)
+				So(c.IsOpen(), ShouldBeFalse)
+				So(err, ShouldNotBeNil)
+				So(p.position, ShouldEqual, 1)
+			})
+
 		})
 
-		Convey("Pool of one, should return the same connection", func() {
-			p := NewConnectionPool(1, ts.URL[8:], ts.TLS.Certificates[0])
-			// need to skip verification for this to accept our cert
-			p.config.InsecureSkipVerify = true
-			c, err := p.GetConnection()
-			So(c, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(p.position, ShouldEqual, 1)
-
-			unique := c.ConnectionState().TLSUnique
-
-			Convey("Position should stay the same and connection should be re-used", func() {
+		Convey("When the gateway is valid and the pool size is one", func() {
+			p := NewTestConnectionPool(1, ts.URL[8:], ts.TLS.Certificates[0])
+			Convey("Should return a connection at position 1", func() {
 				c, err := p.GetConnection()
 				So(c, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 				So(p.position, ShouldEqual, 1)
-				So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
+
+				unique := c.ConnectionState().TLSUnique
+
+				Convey("When called again", func() {
+					Convey("Should return the same connection and position", func() {
+						c, err := p.GetConnection()
+						So(c, ShouldNotBeNil)
+						So(err, ShouldBeNil)
+						So(p.position, ShouldEqual, 1)
+						So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
+					})
+				})
 			})
 		})
 
-		Convey("Pool of two, should loop over connections", func() {
-			p := NewConnectionPool(2, ts.URL[8:], ts.TLS.Certificates[0])
-			So(p.position, ShouldEqual, 0)
-			// need to skip verification for this to accept our cert
-			p.config.InsecureSkipVerify = true
-			c, err := p.GetConnection()
-			So(c, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(p.position, ShouldEqual, 1)
-
-			unique := c.ConnectionState().TLSUnique
-
-			Convey("Position should increase and get a new connection", func() {
+		Convey("When the gateway is valid and the pool size is two", func() {
+			p := NewTestConnectionPool(2, ts.URL[8:], ts.TLS.Certificates[0])
+			var unique, unique2 []byte
+			Convey("Should return a connection at position 1", func() {
 				c, err := p.GetConnection()
 				So(c, ShouldNotBeNil)
 				So(err, ShouldBeNil)
-				So(p.position, ShouldEqual, 2)
-				So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+				So(p.position, ShouldEqual, 1)
+				unique = c.ConnectionState().TLSUnique
 
-				unique2 := c.ConnectionState().TLSUnique
-
-				Convey("Position should go back to 1 and should re-use connection", func() {
-					c, err := p.GetConnection()
-					So(c, ShouldNotBeNil)
-					So(err, ShouldBeNil)
-					So(p.position, ShouldEqual, 1)
-					So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
-
-					Convey("Position should go back to 2 and should re-use connection", func() {
+				Convey("When called a second time", func() {
+					Convey("Should return a new connection at position 2", func() {
 						c, err := p.GetConnection()
 						So(c, ShouldNotBeNil)
 						So(err, ShouldBeNil)
 						So(p.position, ShouldEqual, 2)
-						So(c.ConnectionState().TLSUnique, ShouldResemble, unique2)
+						So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+						unique2 = c.ConnectionState().TLSUnique
+
+						Convey("When called a third time", func() {
+							Convey("Should return first connection at position 1", func() {
+								c, err := p.GetConnection()
+								So(c, ShouldNotBeNil)
+								So(err, ShouldBeNil)
+								So(p.position, ShouldEqual, 1)
+								So(c.ConnectionState().TLSUnique, ShouldResemble, unique)
+
+								Convey("When called a fourth time", func() {
+									Convey("Should return second connection at position 2", func() {
+										c, err := p.GetConnection()
+										So(c, ShouldNotBeNil)
+										So(err, ShouldBeNil)
+										So(p.position, ShouldEqual, 2)
+										So(c.ConnectionState().TLSUnique, ShouldResemble, unique2)
+									})
+								})
+							})
+						})
 					})
 				})
-
 			})
-
 		})
 	})
 }
@@ -117,52 +130,47 @@ func TestApnsConnectionPoolWrite(t *testing.T) {
 
 	poolSize := 10
 	Convey("Write()", t, func() {
-		p := NewConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
-		p.config.InsecureSkipVerify = true // need to skip verification for this to accept our cert
-
-		Convey("Bytes written should match", func() {
-			c, bytesWritten, err := p.Write([]byte("12345"))
-			So(err, ShouldBeNil)
-			So(bytesWritten, ShouldEqual, 5)
-			unique := c.ConnectionState().TLSUnique
-			Convey("Next write should be on different connection", func() {
-				c, bytesWritten, err := p.Write([]byte("test"))
+		Convey("When using a pool > 1", func() {
+			p := NewTestConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
+			Convey("Should return the expected number of bytes written", func() {
+				c, bytesWritten, err := p.Write([]byte("12345"))
 				So(err, ShouldBeNil)
-				So(bytesWritten, ShouldEqual, 4)
-				So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+				So(bytesWritten, ShouldEqual, 5)
+				unique := c.ConnectionState().TLSUnique
+
+				Convey("When performing a second write", func() {
+					Convey("Should be on different connection", func() {
+						c, bytesWritten, err := p.Write([]byte("test"))
+						So(err, ShouldBeNil)
+						So(bytesWritten, ShouldEqual, 4)
+						So(c.ConnectionState().TLSUnique, ShouldNotResemble, unique)
+					})
+
+				})
+
+				Convey("When all connections are closed", func() {
+					p.Close()
+					Convey("Should reconnect", func() {
+						_, bytesWritten, err := p.Write([]byte("6789"))
+						So(err, ShouldBeNil)
+						So(bytesWritten, ShouldEqual, 4)
+					})
+				})
+
 			})
 
-			Convey("If we close all of the connections, should reconnect", func() {
-				p.Close()
+			Convey("When the server is closed", func() {
+				ts.Close()
+				Convey("Should give an error if the server is closed", func() {
+					// force a peek
+					for i := 0; i < poolSize; i++ {
+						p.connections[i].writeCount = peekFrequency
 
-				_, bytesWritten, err := p.Write([]byte("6789"))
-				So(err, ShouldBeNil)
-				So(bytesWritten, ShouldEqual, 4)
+					}
+					_, _, err := p.Write([]byte("test"))
+					So(err, ShouldNotBeNil)
+				})
 			})
-
-		})
-
-		/*
-			Convey("Should return an error if we write 0 bytes", func() {
-				//p.config.InsecureSkipVerify = false // set to false so the handshake fails
-				_, bytesWritten, err := p.Write([]byte("hello"))
-				So(bytesWritten, ShouldEqual, 0)
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "foobar")
-			})
-		*/
-
-		Convey("Should give an error if the server is closed", func() {
-			ts.Close()
-
-			// force a peek
-			for i := 0; i < poolSize; i++ {
-				p.connections[i].writeCount = peekFrequency
-
-			}
-
-			_, _, err := p.Write([]byte("test"))
-			So(err, ShouldNotBeNil)
 
 		})
 	})
@@ -174,22 +182,24 @@ func TestApnsConnectionPoolClose(t *testing.T) {
 
 	poolSize := 10
 	Convey("Close()", t, func() {
-		p := NewConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
-		p.config.InsecureSkipVerify = true // need to skip verification for this to accept our cert
-
-		Convey("Should not return an error if no open connections", func() {
-			err := p.Close()
-			So(err, ShouldBeNil)
+		p := NewTestConnectionPool(poolSize, ts.URL[8:], ts.TLS.Certificates[0])
+		Convey("When there is no open connection", func() {
+			Convey("Should not return an error", func() {
+				err := p.Close()
+				So(err, ShouldBeNil)
+			})
 		})
 
-		Convey("Should not return an error if there are open connections", func() {
+		Convey("When there is an open connection", func() {
 			c, err := p.GetConnection()
 			So(err, ShouldBeNil)
 			So(c.IsOpen(), ShouldBeTrue)
-
-			err = p.Close()
-			So(err, ShouldBeNil)
-			So(c.IsOpen(), ShouldBeFalse)
+			Convey("Should not return an error", func() {
+				err = p.Close()
+				So(err, ShouldBeNil)
+				So(c.IsOpen(), ShouldBeFalse)
+			})
 		})
+
 	})
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,414 @@
+package apns
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestApnsConnectionOpen(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("Open()", t, func() {
+		Convey("Fake server should return an error", func() {
+			err := c.Open("fake", config)
+			So(c.IsOpen(), ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Server with bad certificate should return an error", func() {
+			err := c.Open(ts.URL[8:], config)
+			So(c.IsOpen(), ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+
+		})
+
+		Convey("Server with good certificate should not return an error", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			err := c.Open(ts.URL[8:], config)
+			So(c.IsOpen(), ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionIsOpen(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("Open()", t, func() {
+		Convey("Should be false if we didn't open a connection", func() {
+			So(c.IsOpen(), ShouldBeFalse)
+		})
+
+		Convey("Should be true if we open a connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			So(c.IsOpen(), ShouldBeTrue)
+		})
+
+		Convey("Should be false if the connection expires", func() {
+			c.connectTime = c.connectTime.Add(-(keepAlive + 1) * time.Minute)
+			So(c.IsOpen(), ShouldBeFalse)
+		})
+
+		Convey("Should be false if we close the connection", func() {
+			c.Close()
+			So(c.IsOpen(), ShouldBeFalse)
+		})
+
+		Convey("Open another connection and stop the server", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			So(c.IsOpen(), ShouldBeTrue)
+
+			ts.Close()
+
+			Convey("Should still be considered open", func() {
+				So(c.IsOpen(), ShouldBeTrue)
+			})
+
+			Convey("If we force a peek, should not be open", func() {
+				c.writeCount = peekFrequency
+				So(c.IsOpen(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
+func TestApnsConnectionPeek(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("Peek()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			err := c.Peek()
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Should not return an error on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			err := c.Peek()
+			So(err, ShouldBeNil)
+
+			Convey("Should return an error if we close the connection", func() {
+				c.Close()
+				err := c.Peek()
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Should return an error if we peek on an open connection with a stopped server", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+
+			ts.Close()
+
+			err := c.Peek()
+			So(err, ShouldNotBeNil)
+
+		})
+	})
+
+}
+
+func TestApnsConnectionClose(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("Close()", t, func() {
+		Convey("Should not return an error if we don't have a connection", func() {
+			err := c.Close()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Should not return an error with an open connection, and reset our stats", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			c.writeCount = 10
+			err := c.Close()
+			So(err, ShouldBeNil)
+			So(c.writeCount, ShouldEqual, 0)
+			So(c.connectTime, ShouldResemble, time.Time{})
+		})
+	})
+
+}
+
+func TestApnsConnectionRead(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	buffer := make([]byte, 1, 1)
+
+	Convey("Read()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			_, err := c.Read(buffer)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no connection")
+		})
+
+		Convey("Should timeout on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			c.connection.SetReadDeadline(time.Now().Add(time.Duration(10) * time.Millisecond))
+			_, err := c.Read(buffer)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "i/o timeout")
+		})
+	})
+}
+
+func TestApnsConnectionWrite(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("Write()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			_, err := c.Write([]byte("test"))
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no connection")
+		})
+
+		Convey("Should write the expected bytes on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			n, err := c.Write([]byte("test"))
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, 4)
+		})
+	})
+}
+
+func TestApnsConnectionLocalAddr(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("LocalAddr()", t, func() {
+		Convey("Should return nil if we don't have a connection", func() {
+			a := c.LocalAddr()
+			So(a, ShouldBeNil)
+		})
+
+		Convey("Should not return nil on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			a := c.LocalAddr()
+			So(a, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionRemoteAddr(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("RemoteAddr()", t, func() {
+		Convey("Should return nil if we don't have a connection", func() {
+			a := c.RemoteAddr()
+			So(a, ShouldBeNil)
+		})
+
+		Convey("Should not return nil on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			a := c.RemoteAddr()
+			So(a, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionSetDeadline(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("SetDeadline()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			err := c.SetDeadline(time.Now())
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no connection")
+		})
+
+		Convey("Should not return an error on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			err := c.SetDeadline(time.Now())
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionSetReadDeadline(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("SetReadDeadline()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			err := c.SetReadDeadline(time.Now())
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no connection")
+		})
+
+		Convey("Should not return an error on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			err := c.SetReadDeadline(time.Now())
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionSetWriteDeadline(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("SetWriteDeadline()", t, func() {
+		Convey("Should return an error if we don't have a connection", func() {
+			err := c.SetWriteDeadline(time.Now())
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no connection")
+		})
+
+		Convey("Should not return an error on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			err := c.SetWriteDeadline(time.Now())
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestApnsConnectionConnectionState(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{},
+		ServerName:   ts.URL,
+	}
+
+	c := Connection{}
+	defer c.Close()
+
+	Convey("ConnectionState()", t, func() {
+		Convey("Should return an empty tls.ConnectionState if we don't have a connection", func() {
+			s := c.ConnectionState()
+			So(s, ShouldResemble, tls.ConnectionState{})
+		})
+
+		Convey("Should not return an empty tls.ConnectionState on an open connection", func() {
+			// need to skip verification for this to accept our cert
+			config.InsecureSkipVerify = true
+			c.Open(ts.URL[8:], config)
+			s := c.ConnectionState()
+			So(s, ShouldNotResemble, tls.ConnectionState{})
+		})
+	})
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -131,9 +131,9 @@ func TestApnsConnectionPeek(t *testing.T) {
 
 	Convey("Peek()", t, func() {
 		Convey("When we don't have a connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				err := c.Peek()
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 
@@ -145,9 +145,9 @@ func TestApnsConnectionPeek(t *testing.T) {
 
 				Convey("When we close the connection", func() {
 					c.Close()
-					Convey("Should return an ErrorNoConnection error", func() {
+					Convey("Should return an ErrNoConnection error", func() {
 						err := c.Peek()
-						So(err.Error(), ShouldEqual, ErrorNoConnection)
+						So(err, ShouldEqual, ErrNoConnection)
 					})
 				})
 			})
@@ -213,10 +213,10 @@ func TestApnsConnectionRead(t *testing.T) {
 
 	Convey("Read()", t, func() {
 		Convey("When we don't have an open connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				_, err := c.Read(buffer)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 
@@ -247,10 +247,10 @@ func TestApnsConnectionWrite(t *testing.T) {
 
 	Convey("Write()", t, func() {
 		Convey("When we don't have an open connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				_, err := c.Write([]byte("test"))
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 
@@ -338,10 +338,10 @@ func TestApnsConnectionSetDeadline(t *testing.T) {
 
 	Convey("SetDeadline()", t, func() {
 		Convey("When we don't have an open connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				err := c.SetDeadline(time.Now())
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 
@@ -369,10 +369,10 @@ func TestApnsConnectionSetReadDeadline(t *testing.T) {
 
 	Convey("SetReadDeadline()", t, func() {
 		Convey("When we don't have an open connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				err := c.SetReadDeadline(time.Now())
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 
@@ -400,10 +400,10 @@ func TestApnsConnectionSetWriteDeadline(t *testing.T) {
 
 	Convey("SetWriteDeadline()", t, func() {
 		Convey("When we don't have an open connection", func() {
-			Convey("Should return an ErrorNoConnection error", func() {
+			Convey("Should return an ErrNoConnection error", func() {
 				err := c.SetWriteDeadline(time.Now())
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, ErrorNoConnection)
+				So(err, ShouldEqual, ErrNoConnection)
 			})
 		})
 

--- a/feedback.go
+++ b/feedback.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -53,8 +54,10 @@ func (client *Client) ListenForFeedback() (err error) {
 		return err
 	}
 
+	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		ServerName: gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/feedback.go
+++ b/feedback.go
@@ -57,7 +57,7 @@ func (client *Client) ListenForFeedback() (err error) {
 	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ServerName: gatewayParts[0],
+		ServerName:   gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/push_notification.go
+++ b/push_notification.go
@@ -14,8 +14,8 @@ import (
 // Push commands always start with command value 2.
 const pushCommandValue = 2
 
-// Your total notification payload cannot exceed 256 bytes.
-const MaxPayloadSizeBytes = 256
+// Your total notification payload cannot exceed 2 KB.
+const MaxPayloadSizeBytes = 2048
 
 // Every push notification gets a pseudo-unique identifier;
 // this establishes the upper boundary for it. Apple will return
@@ -40,10 +40,11 @@ const (
 // Alert is an interface here because it supports either a string
 // or a dictionary, represented within by an AlertDictionary struct.
 type Payload struct {
-	Alert interface{} `json:"alert,omitempty"`
-	Badge int         `json:"badge,omitempty"`
-	Sound string      `json:"sound,omitempty"`
-	ContentAvailable int `json:"content-available,omitempty"`
+	Alert            interface{} `json:"alert,omitempty"`
+	Badge            int         `json:"badge,omitempty"`
+	Sound            string      `json:"sound,omitempty"`
+	ContentAvailable int         `json:"content-available,omitempty"`
+	Category         string      `json:"category,omitempty"`
 }
 
 // NewPayload creates and returns a Payload structure.

--- a/push_notification.go
+++ b/push_notification.go
@@ -43,6 +43,7 @@ type Payload struct {
 	Alert interface{} `json:"alert,omitempty"`
 	Badge int         `json:"badge,omitempty"`
 	Sound string      `json:"sound,omitempty"`
+	ContentAvailable int `json:"content-available,omitempty"`
 }
 
 // NewPayload creates and returns a Payload structure.

--- a/push_notification.go
+++ b/push_notification.go
@@ -138,6 +138,9 @@ func (pn *PushNotification) ToBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(token) != deviceTokenLength {
+		return nil, errors.New("device token has incorrect length")
+	}
 	payload, err := pn.PayloadJSON()
 	if err != nil {
 		return nil, err

--- a/push_notification_test.go
+++ b/push_notification_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+const testDeviceToken = "e93b7686988b4b5fd334298e60e73d90035f6d12628a80b4029bde0dec514df9"
+
 // Create a new Payload that specifies simple text,
 // a badge counter, and a custom notification sound.
 func mockPayload() (payload *Payload) {
@@ -41,12 +43,13 @@ func TestBasicAlert(t *testing.T) {
 	payload := mockPayload()
 	pn := NewPushNotification()
 
+	pn.DeviceToken = testDeviceToken
 	pn.AddPayload(payload)
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 98 {
-		t.Error("expected 98 bytes; got", len(bytes))
+	if len(bytes) != 130 {
+		t.Error("expected 130 bytes; got", len(bytes))
 	}
 	if len(json) != 69 {
 		t.Error("expected 69 bytes; got", len(json))
@@ -59,12 +62,13 @@ func TestAlertDictionary(t *testing.T) {
 	payload.Alert = dict
 
 	pn := NewPushNotification()
+	pn.DeviceToken = testDeviceToken
 	pn.AddPayload(payload)
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 223 {
-		t.Error("expected 223 bytes; got", len(bytes))
+	if len(bytes) != 255 {
+		t.Error("expected 255 bytes; got", len(bytes))
 	}
 	if len(json) != 194 {
 		t.Error("expected 194 bytes; got", len(bytes))
@@ -75,6 +79,7 @@ func TestCustomParameters(t *testing.T) {
 	payload := mockPayload()
 	pn := NewPushNotification()
 
+	pn.DeviceToken = testDeviceToken
 	pn.AddPayload(payload)
 	pn.Set("foo", "bar")
 
@@ -87,7 +92,7 @@ func TestCustomParameters(t *testing.T) {
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 110 {
+	if len(bytes) != 142 {
 		t.Error("expected 110 bytes; got", len(bytes))
 	}
 	if len(json) != 81 {


### PR DESCRIPTION
@richpoirier Ready for review

I updated the library to be in sync with upstream fork. I then replaced our single connection, with a more robust connection pool.

Here are the main changes:
- instead of using a single connection, use a connection pool (currently set to a size of 5, round-robin)
- connections will live for 10 minutes
- when writing, will attempt all connections if necessary
- after 25 writes we perform a peek on the connection to see if it is still alive. this is to combat the issue where the server closes on us and writes still go through eventhough there's no one receiving them (the problem we were using cron for)

This still doesn't fix the speed issue. I'm logging failure times to see how much we can reduce the success timeout. 
